### PR TITLE
Allow optional title

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -85,7 +85,7 @@ function scopedChain(parent) {
     title = prefix ? prefix.join(' ') : null;
     var targetArgs = title ? [title] : [];
     targetArgs = fn ? targetArgs.concat(fn) : targetArgs;
-    return target.apply(target, [title, fn]);
+    return target.apply(target, targetArgs);
   });
 
   return chain.test;

--- a/spec/test.js
+++ b/spec/test.js
@@ -5,6 +5,10 @@ test.beforeEach(function (t) {
   t.context.test = 'test';
 });
 
+test(function (t) {
+  t.is(true, true);
+});
+
 test('is compatible with ava', function (t) {
   t.is(true, true);
 });

--- a/spec/test.js
+++ b/spec/test.js
@@ -10,7 +10,7 @@ test('is compatible with ava', function (t) {
 });
 
 test('is compatible with ava context', function (t) {
-  t.true(t.context.test, 'test');
+  t.true(t.context.test === 'test');
 });
 
 test.describe('describe', function (test) {

--- a/spec/test.js
+++ b/spec/test.js
@@ -1,8 +1,16 @@
 'use strict';
 var test = require('../');
 
+test.beforeEach(function (t) {
+  t.context.test = 'test';
+});
+
 test('is compatible with ava', function (t) {
   t.is(true, true);
+});
+
+test('is compatible with ava context', function (t) {
+  t.true(t.context.test, 'test');
 });
 
 test.describe('describe', function (test) {


### PR DESCRIPTION
Add `beforeEach` to integration tests, currently fails on AVA 0.15.1

Edit: it turns out arguments weren't properly being passed to AVA which prevented test without titles (and `beforeEach` hooks) to be properly invoked on AVA internally.
